### PR TITLE
go reports-service: Fix null report sources

### DIFF
--- a/go/services/reports/internal/services/reports_service.go
+++ b/go/services/reports/internal/services/reports_service.go
@@ -571,6 +571,7 @@ func (s *ReportsService) getApplicationIncidentFromInsight(
 
 	if len(insight.Metadata) == 0 {
 		s.logger.Info("Metadata is empty", zap.Any("metadata", insight), zap.Any("conf", configuration))
+		sources = make([]repositories.ApplicationIncidentSource, 0)
 	}
 
 	return &repositories.ApplicationIncident{
@@ -626,6 +627,11 @@ func (s *ReportsService) getNodeIncidentFromInsight(insight insights.NodeInsight
 			Filename:  metadata.Filename,
 		}
 	})(insight.Metadata)
+
+	if len(insight.Metadata) == 0 {
+		s.logger.Info("Metadata is empty", zap.Any("metadata", insight), zap.Any("conf", configuration))
+		sources = make([]repositories.NodeIncidentSource, 0)
+	}
 
 	return &repositories.NodeIncident{
 		ClusterId:      insight.Metadata[0].ClusterId,

--- a/go/services/reports/pkg/insights/node_insights.go
+++ b/go/services/reports/pkg/insights/node_insights.go
@@ -251,11 +251,6 @@ func (g *OpenAiInsightsGenerator) GetScheduledNodeInsights(
 		return nil, err
 	}
 
-	if err != nil {
-		g.logger.Error("Failed to get application logs for scheduled insight")
-		return nil, err
-	}
-
 	insights, err := g.getNodeInsightsFromBatchEntries(completionResponses, scheduledInsights)
 	if err != nil {
 		g.logger.Error("Failed to transform batch entries into node insights")
@@ -289,11 +284,6 @@ func (g *OpenAiInsightsGenerator) AwaitScheduledNodeInsights(
 	completionResponses, err := g.client.CompletionResponseEntriesFromBatches(batches)
 	if err != nil {
 		g.logger.Error("Failed to get node batch completion responses", zap.Error(err))
-		return nil, err
-	}
-
-	if err != nil {
-		g.logger.Error("Failed to get application logs for scheduled insight")
 		return nil, err
 	}
 


### PR DESCRIPTION
- Make incident sources and empty list instead of null in case of LLM not returning any valid incident sources